### PR TITLE
Fix curried chain Either type variant

### DIFF
--- a/packages/prelude/src/chain.ts
+++ b/packages/prelude/src/chain.ts
@@ -29,5 +29,5 @@ export type Chain = {
   <A, B>(f: (value: A, index: number) => List<B>): (list: List<A>) => Array<B>
   <A, B>(f: (value: A) => Maybe<B>): (maybe: Maybe<A>) => Maybe<B>
   <A, B>(f: (value: A) => PromiseLike<B>): (promise: PromiseLike<A>) => Promise<B>
-  <A, B, C>(f: (value: A) => Either<A, C>): (either: Either<A, B>) => Either<A, C>
+  <A, B, C>(f: (value: B) => Either<A, C>): (either: Either<A, B>) => Either<A, C>
 }


### PR DESCRIPTION
Fix the curried `Chain` type variant for `Either`, making it match the uncurried variant and correctly apply `f` to `B` instead of `A`.

I'd be happy to add a test that fails type checking, but I'm not quite sure why the existing tests passed.  Perhaps defaulting `B` to `any` [here](https://github.com/TylorS/typed/blob/master/packages/either/src/Either.ts#L17) is hiding type errors? What do you think?